### PR TITLE
159 Can't select desired route

### DIFF
--- a/app/components/routeSelector.tsx
+++ b/app/components/routeSelector.tsx
@@ -19,7 +19,7 @@ export function RouteSelector({
     if (interactive) {
       handler(routesArr[0]); // Select first route by default
     }
-  }, [interactive, handler, routesArr]);
+  }, []); // Run ONLY on first load!
 
   return (
     <div>


### PR DESCRIPTION
## The :bug: 

- As predicted in [the issue](https://github.com/cbarkr/transmiss/issues/159), the `useEffect` was not configured to run only on initial load, and was thus being re-run any time there was a change in state
- This prevented anything but the first item from being selected!

## The fix

- Provide an empty array as the second argument to `useEffect` (per [this SO post](https://stackoverflow.com/a/53121021))